### PR TITLE
BREAKING CHANGE: update typedoc config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/dev-config",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "description": "A set of standard typescript config and tslint options for Salesforce projects.",
   "repository": "forcedotcom/dev-config",
   "main": "index.js",

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,14 +1,9 @@
 module.exports = {
   includes: 'src',
 
-  mode: 'file',
-  module: 'commonjs',
   excludeExternals: true,
-  excludeNotExported: true,
   excludePrivate: true,
 
-  includeDeclarations: true,
-  target: 'ES6',
   hideGenerator: true,
   theme: 'minimal'
 };


### PR DESCRIPTION
### What does this PR do?
Update `typedoc` config file for [typedoc 0.20](https://github.com/TypeStrong/typedoc/releases/tag/v0.20.0).
This config file isn't compatible with typedoc < 0.20

### What issues does this PR fix or reference?
@W-10159876@
