### PR TITLE
feat: node18+ lib/target/module stuff

### DIFF
--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "Node16",
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2023"],
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "Node16",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2021",
-    "lib": ["es2021"],
+    "module": "Node16",
+    "target": "ES2022",
+    "lib": ["ES2023"],
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "node",


### PR DESCRIPTION
most plugins are on esm
the libraries aren't and were behind lib/target from the node16 days

ref: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping