### PR TITLE
feat: node16 module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2023"],
     "sourceMap": true,
     "declaration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node16",
     "alwaysStrict": true,
     "noUnusedLocals": true
   }


### PR DESCRIPTION
recent TS versions (ex 5.5+) will throw
tsconfig.json:6:3 - error TS5109: Option 'moduleResolution' must be set to 'Node16' (or left unspecified) when option 'module' is set to 'Node16'.

like https://github.com/forcedotcom/ts-sinon/actions/runs/10129719992/job/28010100376?pr=291#step:7:14

our `-esm` tsconfigs are already doing that, but our non-esm (mostly libraries) aren't.  